### PR TITLE
Add PeriodicActor

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ class ExampleTickMessage(conclib.ActorMessage):
 
 class ExamplePeriodicActor(conclib.PeriodicActor):
     URN = "example_periodic_actor"
+    # This is the type of message, and how often to send it
     TICKS = {
         ExampleTickMessage: 0.5,
     }

--- a/README.md
+++ b/README.md
@@ -81,12 +81,14 @@ import conclib
 
 class ExampleActor(conclib.Actor):
     URN = "example_actor"
+    # URN is optional here, but recommended so that actor-to-actor 
+    # communication can use the urn string instead of the actor ref.
+    # If using the proxy, the URN is more-or-less required to be able
+    # to address the inbound messages.
+    
     def __init__(self):
-        # URN is optional here, but recommended so that actor-to-actor 
-        # communication can use the urn string instead of the actor ref.
-        # If using the proxy, the URN is more-or-less required to be able
-        # to address the inbound messages.
-        super().__init__(urn=self.URN)
+        
+        super().__init__()
 
     def on_receive(self, message):
         # Check if the message is a RequestEnvelope (i.e. a message that arrived from 
@@ -151,7 +153,7 @@ class PrintTimeActor(conclib.Actor):
 
     def __init__(self):
         self.ticker = PrintTimeTicker(self.URN)
-        super().__init__(urn=self.URN)
+        super().__init__()
     
     def on_start(self):
         # Start the ticker when the actor starts and not in __init__. This 
@@ -195,4 +197,35 @@ rest_daemon = conclib.start_api(
 
 # Shut down the REST API when you are done to prevent blocking the main process shutting down
 rest_daemon.shutdown()
+```
+
+## Usage - PeriodicActor
+
+A very common pattern right now is an actor that runs a function at a regular interval. This
+adds a bunch of boilerplate to every actor that needs this behavior. `PeriodicActor` is a
+convenience class that handles this boilerplate. It is an actor that has one or more child 
+tickers. Each `Ticker` sends a specific `ActorMessage` to the `PeriodicActor` at a regular
+interval. 
+
+NOTE: If you override `on_stop`, `on_start` or `on_failure` in a `PeriodicActor`, you must
+call `super()` (e.g. `super().on_stop()`) to make sure the tickers are started/stopped correctly.
+
+```python
+import conclib
+
+class ExampleTickMessage(conclib.ActorMessage):
+    pass
+
+
+class ExamplePeriodicActor(conclib.PeriodicActor):
+    URN = "example_periodic_actor"
+    TICKS = {
+        ExampleTickMessage: 0.5,
+    }
+
+    def on_receive(self, message: conclib.ActorMessage) -> None:
+        if isinstance(message, ExampleTickMessage):
+            print("Tick")
+        else:
+            raise conclib.errors.UnexpectedMessageError(message)
 ```

--- a/conclib/__init__.py
+++ b/conclib/__init__.py
@@ -10,6 +10,7 @@ from conclib.proxy.client import ProxyClient  # noqa: F401
 
 from conclib.proxy.envelope import RequestEnvelope, ResponseEnvelope  # noqa: F401
 from conclib.proxy.actor import start_proxy  # noqa: F401
+from conclib.pykka_extensions.periodicactor import PeriodicActor  # noqa: F401
 
 from conclib.utils.redisd.redisserverd import start_redis  # noqa: F401
 from conclib.utils.apid.apid import start_api  # noqa: F401

--- a/conclib/pykka_extensions/actor.py
+++ b/conclib/pykka_extensions/actor.py
@@ -10,10 +10,22 @@ from typing import Optional
 # - Changed the actor urn so that it can be passed in at creation time.
 # - Changed to use a daemon thread.
 class Actor(pykka.ThreadingActor):
+    URN: str | None = None  # CHANGED
     use_daemon_thread = True  # CHANGED
 
-    def __init__(self, urn: Optional[str], *args, **kwargs):  # noqa
-        self.actor_urn = urn if urn else uuid.uuid4().urn  # CHANGED
+    def __init__(self, urn: Optional[str] = None, *args, **kwargs):  # noqa  # CHANGED
+
+        ### CHANGED ###
+        final_urn = None
+        if self.URN:
+            final_urn = self.URN
+        if urn:
+            final_urn = urn
+        if not final_urn:
+            final_urn = str(uuid.uuid4().urn)
+        ### END CHANGED ###
+
+        self.actor_urn = final_urn   # CHANGED
         self.actor_inbox = self._create_actor_inbox()
         self.actor_stopped = threading.Event()
         self._actor_ref = ActorRef(self)

--- a/conclib/pykka_extensions/periodicactor.py
+++ b/conclib/pykka_extensions/periodicactor.py
@@ -58,7 +58,8 @@ class ExampleTickMessage(conclib.ActorMessage):
 
 
 class ExamplePeriodicActor(PeriodicActor):
-    URN = "example_actor"
+    URN = "example_periodic_actor"
+    # This is the type of message, and how often to send it
     TICKS = {
         ExampleTickMessage: 0.5,
     }

--- a/conclib/pykka_extensions/periodicactor.py
+++ b/conclib/pykka_extensions/periodicactor.py
@@ -1,0 +1,81 @@
+import conclib
+from conclib.pykka_extensions.ticker import ChildTicker
+from types import TracebackType
+from typing import Optional
+
+TickFrequency = float
+ActorMessageType = type[conclib.ActorMessage]
+
+
+class PeriodicActor(conclib.Actor):
+    """
+    Actor with one or more Tickers built-in.
+
+    IMPORTANT: If you override on_start, on_stop, or on_failure, you must class
+    super() on them so that startup and cleanup happen.
+    """
+    TICKS: dict[ActorMessageType, TickFrequency] = {}
+
+    def __init__(self):
+        super().__init__()
+        self.tickers: list[ChildTicker] = []
+        for message_type, interval in self.TICKS.items():
+            new_ticker = ChildTicker(
+                interval=interval,
+                actor_ref=self.actor_ref,
+                message_type=message_type
+            )
+            self.tickers.append(new_ticker)
+
+    def start_tickers(self):
+        for ticker in self.tickers:
+            ticker.start()
+
+    def stop_tickers(self):
+        for ticker in self.tickers:
+            ticker.stop()
+
+    def on_start(self) -> None:
+        """ If this is overridden, super().on_start() must be called. """
+        self.start_tickers()
+
+    def on_stop(self) -> None:
+        """ If this is overridden, super().on_stop() must be called. """
+        self.stop_tickers()
+
+    def on_failure(
+        self,
+        exception_type: Optional[type[BaseException]],
+        exception_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> None:
+        """ If this is overridden, super().on_failure() must be called. """
+        self.stop_tickers()
+
+
+class ExampleTickMessage(conclib.ActorMessage):
+    pass
+
+
+class ExamplePeriodicActor(PeriodicActor):
+    URN = "example_actor"
+    TICKS = {
+        ExampleTickMessage: 0.5,
+    }
+
+    def on_receive(self, message: conclib.ActorMessage) -> None:
+        if isinstance(message, ExampleTickMessage):
+            print("Tick")
+        else:
+            raise conclib.errors.UnexpectedMessageError(message)
+
+
+if __name__ == '__main__':
+    import time
+    import pykka
+
+    ExamplePeriodicActor.start()
+    try:
+        time.sleep(5)
+    finally:
+        pykka.ActorRegistry.stop_all()

--- a/conclib/pykka_extensions/ticker.py
+++ b/conclib/pykka_extensions/ticker.py
@@ -6,16 +6,25 @@ import time
 
 from typing import Optional
 
+import pykka
+
+import conclib
+
 
 # Class to run code every X seconds. This type of work doesn't fit well into the pykka actor model.
 # This should generally be used to send a message to an actor every X second and have the logic
 # exist inside that actor.
 class Ticker(threading.Thread):
-    def __init__(self, interval=10) -> None:
+    def __init__(
+            self,
+            interval: float = 10,
+            thread_name: str | None = None
+    ) -> None:
         self.shutdown_queue = queue.Queue()
-        self.interval: float = interval
+        self.interval = interval
         self.next_scheduled_time: Optional[int] = None
-        super().__init__(name=f"{self.__class__.__name__}-{uuid.uuid4()}")
+        thread_name = thread_name or f"{self.__class__.__name__}-{uuid.uuid4()}"
+        super().__init__(name=thread_name)
 
     def stop(self):
         self.shutdown_queue.put(None)
@@ -39,3 +48,24 @@ class Ticker(threading.Thread):
             except queue.Empty:
                 self.next_scheduled_time = time.time() + self.interval
                 self.execute()
+
+
+class ChildTicker(Ticker):
+    """
+    A ticker that is created by a parent actor and sends a type of message to the parent actor.
+    This is a utility class to be able to create a PeriodicActor which reduces boilerplate.
+    """
+    def __init__(
+            self,
+            interval: float,
+            actor_ref: pykka.ActorRef,
+            message_type: type[conclib.ActorMessage]
+    ) -> None:
+        self.actor_ref = actor_ref
+        self.message_type = message_type
+        # Generate a name based on the Actor class, the frequency, and the message type
+        thread_name = f"{self.actor_ref.actor_class.__name__}-{interval}-{self.message_type.__name__}"
+        super().__init__(interval=interval, thread_name=thread_name)
+
+    def execute(self):
+        self.actor_ref.tell(self.message_type())

--- a/periodic_actor_test.py
+++ b/periodic_actor_test.py
@@ -1,0 +1,57 @@
+import conclib
+
+class AccumulateMessage(conclib.ActorMessage):
+    pass
+
+class CheckMessage(conclib.ActorMessage):
+    pass
+
+class AccumulatorActor(conclib.PeriodicActor):
+    URN = "accumulator"
+    TICKS = {
+        AccumulateMessage: 0.2,
+        CheckMessage: 1.02,
+    }
+
+    def __init__(self):
+        super().__init__()
+        self.counter = 0
+        self.is_first_check = True
+        self.is_first_accumulate = True
+
+    def on_receive(self, message: conclib.ActorMessage) -> None:
+        if isinstance(message, AccumulateMessage):
+            # Ignore the first check message because it will fire immediately on start
+            # and the order is undefined.
+            if self.is_first_accumulate:
+                self.is_first_accumulate = False
+                return
+
+            print("Accumulating")
+            self.counter += 1
+
+        elif isinstance(message, CheckMessage):
+            # Ignore the first check message because it will fire immediately on start
+            # and the order is undefined.
+            if self.is_first_check:
+                self.is_first_check = False
+                return
+
+            print("Checking")
+            if self.counter != 5:
+                print("Check failed")
+                raise RuntimeError("Counter should be 6")
+            self.counter = 0
+            print("Check passed")
+        else:
+            raise conclib.errors.UnexpectedMessageError(message)
+
+
+if __name__ == '__main__':
+    import time
+    import pykka
+    try:
+        AccumulatorActor.start()
+        time.sleep(5)
+    finally:
+        pykka.ActorRegistry.stop_all()

--- a/periodic_actor_test.py
+++ b/periodic_actor_test.py
@@ -1,10 +1,13 @@
 import conclib
 
+
 class AccumulateMessage(conclib.ActorMessage):
     pass
 
+
 class CheckMessage(conclib.ActorMessage):
     pass
+
 
 class AccumulatorActor(conclib.PeriodicActor):
     URN = "accumulator"


### PR DESCRIPTION
Added a `PeriodicActor` to hide the boilerplate of having an `Actor` with a `Ticker` child. 

Also changed the `self.URN` from a convention to a feature. `__init__` based URN definition as well as autogenerated URN are still allowed, but are discouraged and have been removed from documentation.